### PR TITLE
HotFix: Fixed inhale and hitstun

### DIFF
--- a/KirbyDarkDoom/Assets/Scenes/TestScene.unity
+++ b/KirbyDarkDoom/Assets/Scenes/TestScene.unity
@@ -410,7 +410,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 1882758785545764, guid: 8051d656925bf4686b3424fef63bf534, type: 2}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8051d656925bf4686b3424fef63bf534, type: 2}
@@ -557,7 +557,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 1929310450321584, guid: b86ace3e9e6e64acb8362b8e9f6aed09, type: 2}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 114115793518424288, guid: b86ace3e9e6e64acb8362b8e9f6aed09,
         type: 2}
@@ -985,6 +985,12 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &995206129 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114351683028360494, guid: d015d78c3048e44f592f6afd7caf9daf,
+    type: 2}
+  m_PrefabInternal: {fileID: 1205903244}
+  m_Script: {fileID: 11500000, guid: 06ef3d963c21943689052fbce2193bb5, type: 3}
 --- !u!1 &1003893184
 GameObject:
   m_ObjectHideFlags: 0
@@ -1268,6 +1274,11 @@ Prefab:
     - target: {fileID: 114351683028360494, guid: d015d78c3048e44f592f6afd7caf9daf,
         type: 2}
       propertyPath: maxYPos
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114351683028360494, guid: d015d78c3048e44f592f6afd7caf9daf,
+        type: 2}
+      propertyPath: minYPos
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -2114,7 +2125,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 1998890575695690, guid: 4c6826945c1f9458e9d29c25a1dc2c32, type: 2}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 114873784984551542, guid: 4c6826945c1f9458e9d29c25a1dc2c32,
         type: 2}
@@ -2165,7 +2176,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 1882758785545764, guid: 8051d656925bf4686b3424fef63bf534, type: 2}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1882758785545764, guid: 8051d656925bf4686b3424fef63bf534, type: 2}
       propertyPath: m_Name
@@ -2218,6 +2229,11 @@ Prefab:
       propertyPath: fadeOverlay
       value: 
       objectReference: {fileID: 1473171877}
+    - target: {fileID: 114729666768961980, guid: 31c868277f203414ca337849258295bb,
+        type: 2}
+      propertyPath: mainCamera
+      value: 
+      objectReference: {fileID: 995206129}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 31c868277f203414ca337849258295bb, type: 2}
   m_IsPrefabAsset: 0

--- a/KirbyDarkDoom/Assets/Scripts/PlayerController.cs
+++ b/KirbyDarkDoom/Assets/Scripts/PlayerController.cs
@@ -100,6 +100,11 @@ public class PlayerController : MonoBehaviour {
             playerCollider.size = new Vector2(1,duckHeight);
             playerCollider.offset = new Vector2(0,duckOffset);
         }
+        if(isInhaling == true)
+        {
+            inhaleHitboxChild.SetActive(false);
+            isInhaling = false;
+        }
 
         // Calls all of the invoke methods to make sure all of the states are reset
         ResetExhaleState();
@@ -116,7 +121,6 @@ public class PlayerController : MonoBehaviour {
 
         // And nothing is in the player's mouth
         isStuffed = false;
-        isInhaling = false;
 
         // And reset their speed to be 0
         playerRB.velocity = Vector2.zero;
@@ -164,7 +168,7 @@ public class PlayerController : MonoBehaviour {
         GraphicUpdate();
 
         // If the player is exhaling or dying, they cannot do any actions
-        if(isExhaling == false && playerHealth.IsDying == false)
+        if(isExhaling == false && playerHealth.IsDying == false && isTakingDamage == false)
         {
             // If the player is inhaling or ducking, they cannot move or jump
             if(isInhaling == false && isDucking == false)
@@ -245,8 +249,20 @@ public class PlayerController : MonoBehaviour {
             }
             else if(isTakingDamage == false && playerHealth.isInvincible == false)
             {
+                // We first stop specific states if they are valid
+                if(isDucking == true)
+                {
+                    playerCollider.size = new Vector2(1,duckHeight);
+                    playerCollider.offset = new Vector2(0,duckOffset);
+                    isDucking = false;
+                }
+                if(isInhaling == true)
+                {
+                    inhaleHitboxChild.SetActive(false);
+                    isInhaling = false;
+                }
+
                 // The player takes damage if they run into an enemy
-                ResetPlayerMovement(isFacingRight);
                 playerHealth.TakeDamage(collision.gameObject.GetComponent<BaseEnemy>().attackPower);
                 playerHealth.ActivateInvincibility();
                 isTakingDamage = true;
@@ -534,7 +550,7 @@ public class PlayerController : MonoBehaviour {
                 }
             }
         }
-        else if(Input.GetKey(KeyCode.H) && isTakingDamage == false)
+        else if(Input.GetKey(KeyCode.H))
         {
             // This occurs immediatly as soon as the player inhaled an enemy
             if(isStuffed == true)

--- a/KirbyDarkDoom/Assets/Scripts/SlideHitbox.cs
+++ b/KirbyDarkDoom/Assets/Scripts/SlideHitbox.cs
@@ -17,23 +17,26 @@ public class SlideHitbox : MonoBehaviour {
 	// If the player runs into a specific entiry, 
 	private void OnTriggerEnter2D(Collider2D collision)
 	{
-        if(collision.gameObject.GetComponent<BaseHealth>() != null)
+        if(collision.gameObject.layer == LayerMask.NameToLayer("Indestructable") || collision.gameObject.layer == LayerMask.NameToLayer("Destructable"))
         {
-            // If the entiry we run into has healh, we damage said entity
-            collision.gameObject.GetComponent<BaseHealth>().TakeDamage(slideAttackPower);
-
-            if(collision.gameObject.tag == "Enemy")
+            if(collision.gameObject.GetComponent<BaseHealth>() != null)
             {
-                // If the player ran into an enemy, the player will stop its slide
+                // If the entiry we run into has healh, we damage said entity
+                collision.gameObject.GetComponent<BaseHealth>().TakeDamage(slideAttackPower);
+
+                if(collision.gameObject.tag == "Enemy")
+                {
+                    // If the player ran into an enemy, the player will stop its slide
+                    player.isSliding = false;
+                    gameObject.SetActive(false);
+                }
+            }
+            else
+            {
+                // We stop the slide if the player is hitting a solid object
                 player.isSliding = false;
                 gameObject.SetActive(false);
             }
-        }
-        else
-        {
-            // Anything else, the player will stop its slide
-            player.isSliding = false;
-            gameObject.SetActive(false);
         }
 	}
 }


### PR DESCRIPTION
# BugFix
- Fixed issue where if player was inhaling while getting hit, the inhale hitbox will still be there and the player will still be inhaling afterwards.