### PR TITLE
Cleanup, Small Additions

### DIFF
--- a/KirbyDarkDoom/Assets/Prefabs/TestBomb.prefab
+++ b/KirbyDarkDoom/Assets/Prefabs/TestBomb.prefab
@@ -157,6 +157,7 @@ MonoBehaviour:
   maxHealth: 1
   isInvincible: 0
   invincibilityTime: 2
+  canBeInhaled: 1
   spawnLocation: {x: 0, y: 0}
   entitySpriteRender: {fileID: 212019272010774246}
 --- !u!114 &114648772212619250
@@ -177,6 +178,7 @@ MonoBehaviour:
   hitboxXSize: 1.5
   hitboxYSize: 1
   hitboxTimer: 1
+  objectHealth: {fileID: 114611346937476530}
   hitboxRef: {fileID: 61869570419011186}
   objectRB: {fileID: 50671475493125694}
   objectSprite: {fileID: 212019272010774246}

--- a/KirbyDarkDoom/Assets/Prefabs/TestMiniBoss.prefab
+++ b/KirbyDarkDoom/Assets/Prefabs/TestMiniBoss.prefab
@@ -41,6 +41,8 @@ GameObject:
   - component: {fileID: 114336949428024796}
   - component: {fileID: 114191752791798554}
   - component: {fileID: 114389335611510454}
+  - component: {fileID: 114075140755556464}
+  - component: {fileID: 114666031931447546}
   m_Layer: 9
   m_Name: TestMiniBoss
   m_TagString: MiniBoss
@@ -120,6 +122,20 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2.4, y: 2.78}
   m_EdgeRadius: 0
+--- !u!114 &114075140755556464
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1851551426365548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c57d20a7f9ffd4a60be8e38647d3211f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  listOfRelatedObjects:
+  - {fileID: 0}
+  - {fileID: 0}
 --- !u!114 &114191752791798554
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -152,7 +168,6 @@ MonoBehaviour:
   enemySprite: {fileID: 212105829403050546}
   enemyRB: {fileID: 50357400346206562}
   frontOfEnemy: {fileID: 4729213315812772}
-  currentState: 0
   dashSpeed: 700
   bombThrowSpeed: 10
   jumpPower: 800
@@ -179,10 +194,36 @@ MonoBehaviour:
   maxHealth: 60
   isInvincible: 0
   invincibilityTime: 2
+  canBeInhaled: 0
   spawnLocation: {x: 0, y: 0}
   entitySpriteRender: {fileID: 212105829403050546}
+  enemyActions: {fileID: 114336949428024796}
+  enemyGraphics: {fileID: 114191752791798554}
+  explodeComponent: {fileID: 114666031931447546}
   bossName_UI: {fileID: 0}
   bossHealthBar_UI: {fileID: 0}
+--- !u!114 &114666031931447546
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1851551426365548}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f53f644605e6e4df4aa5d2564e98e63c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  canExplode: 1
+  timeToDestroy: 3
+  explosionSprite: {fileID: 21300000, guid: 9b170821e8499411caa3f5b9c802c41b, type: 3}
+  explosionPower: 20
+  hitboxXSize: 2.4
+  hitboxYSize: 2.78
+  hitboxTimer: 2
+  objectHealth: {fileID: 114389335611510454}
+  hitboxRef: {fileID: 61648410391567178}
+  objectRB: {fileID: 50357400346206562}
+  objectSprite: {fileID: 212105829403050546}
 --- !u!212 &212105829403050546
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/KirbyDarkDoom/Assets/Scenes/Prototype.unity
+++ b/KirbyDarkDoom/Assets/Scenes/Prototype.unity
@@ -1544,6 +1544,16 @@ Prefab:
       propertyPath: bossHealthBar_UI
       value: 
       objectReference: {fileID: 1565043909}
+    - target: {fileID: 114075140755556464, guid: 93cd873cd7821408f9ae6e924fa75569,
+        type: 2}
+      propertyPath: listOfRelatedObjects.Array.data[0]
+      value: 
+      objectReference: {fileID: 1934965005}
+    - target: {fileID: 114075140755556464, guid: 93cd873cd7821408f9ae6e924fa75569,
+        type: 2}
+      propertyPath: listOfRelatedObjects.Array.data[1]
+      value: 
+      objectReference: {fileID: 160102659}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93cd873cd7821408f9ae6e924fa75569, type: 2}
   m_IsPrefabAsset: 0
@@ -1557,20 +1567,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4358065122455902, guid: 93cd873cd7821408f9ae6e924fa75569,
     type: 2}
   m_PrefabInternal: {fileID: 298186932}
---- !u!114 &298186935
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 298186933}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c57d20a7f9ffd4a60be8e38647d3211f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  listOfRelatedObjects:
-  - {fileID: 160102659}
-  - {fileID: 1934965005}
 --- !u!1 &308277240
 GameObject:
   m_ObjectHideFlags: 0

--- a/KirbyDarkDoom/Assets/Scenes/TestScene_3.unity
+++ b/KirbyDarkDoom/Assets/Scenes/TestScene_3.unity
@@ -681,20 +681,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1851551426365548, guid: 93cd873cd7821408f9ae6e924fa75569,
     type: 2}
   m_PrefabInternal: {fileID: 1374822688}
---- !u!114 &381940498
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 381940497}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c57d20a7f9ffd4a60be8e38647d3211f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  listOfRelatedObjects:
-  - {fileID: 165098309}
-  - {fileID: 1522685175}
 --- !u!1 &382027189
 GameObject:
   m_ObjectHideFlags: 0
@@ -1786,9 +1772,29 @@ Prefab:
       propertyPath: bossHealthBar_UI
       value: 
       objectReference: {fileID: 1205889675}
+    - target: {fileID: 114075140755556464, guid: 93cd873cd7821408f9ae6e924fa75569,
+        type: 2}
+      propertyPath: listOfRelatedObjects.Array.data[0]
+      value: 
+      objectReference: {fileID: 165098309}
+    - target: {fileID: 114075140755556464, guid: 93cd873cd7821408f9ae6e924fa75569,
+        type: 2}
+      propertyPath: listOfRelatedObjects.Array.data[1]
+      value: 
+      objectReference: {fileID: 1522685175}
     - target: {fileID: 1851551426365548, guid: 93cd873cd7821408f9ae6e924fa75569, type: 2}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114666031931447546, guid: 93cd873cd7821408f9ae6e924fa75569,
+        type: 2}
+      propertyPath: timeToDestroy
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114389335611510454, guid: 93cd873cd7821408f9ae6e924fa75569,
+        type: 2}
+      propertyPath: maxHealth
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93cd873cd7821408f9ae6e924fa75569, type: 2}

--- a/KirbyDarkDoom/Assets/Scripts/BaseEnemy.cs
+++ b/KirbyDarkDoom/Assets/Scripts/BaseEnemy.cs
@@ -11,7 +11,8 @@ public enum EnemyStates{
     IDLE,
     ATTACK1,
     ATTACK2,
-    COOLDOWN
+    COOLDOWN,
+    DEFEAT
 }
 
 public abstract class BaseEnemy : MonoBehaviour {

--- a/KirbyDarkDoom/Assets/Scripts/BaseHealth.cs
+++ b/KirbyDarkDoom/Assets/Scripts/BaseHealth.cs
@@ -12,6 +12,7 @@ public abstract class BaseHealth : MonoBehaviour {
     public float maxHealth;
     public bool isInvincible = false;
     public float invincibilityTime = 2f;
+    public bool canBeInhaled = true;            // Can this object be inhalled?
     public Vector2 spawnLocation;               // The respawn location that the entity will use when calling Respawn()
 
     [Header("Base Components")]

--- a/KirbyDarkDoom/Assets/Scripts/BombMiniBossActions.cs
+++ b/KirbyDarkDoom/Assets/Scripts/BombMiniBossActions.cs
@@ -10,7 +10,6 @@ using UnityEngine;
 public class BombMiniBossActions : BaseEnemy {
 
     [Header("Sub General Vars")]
-    public EnemyStates currentState;
     public float dashSpeed;
     public float bombThrowSpeed;
     public float jumpPower;
@@ -29,15 +28,37 @@ public class BombMiniBossActions : BaseEnemy {
     public EnemyGraphics bossGraphics;
 
     // Private variables
+    private EnemyStates currentState;       // The current state of the miniboss, which determines its specific actions
     private bool hasActivatedCooldown;
     private bool isMovingForward;
     private float origSpeed;
     private GameObject spawnedBombInstance;
 
+    public EnemyStates CurrentState {
+        get {return currentState;}
+        set {
+            // When you switch states, its graphics will change accordingly
+            switch(value)
+            {
+                case EnemyStates.IDLE:
+                    bossGraphics.SwitchSprite("normal");
+                    break;
+                case EnemyStates.ATTACK1:
+                case EnemyStates.ATTACK2:
+                    bossGraphics.SwitchSprite("attack");
+                    break;
+                case EnemyStates.DEFEAT:
+                    bossGraphics.SwitchSprite("defeat");
+                    break;
+            }
+            currentState = value;
+        }
+    }
+
     // Determines how the boss will move around
     public override void Move()
     {
-        switch(currentState)
+        switch(CurrentState)
         {
             case EnemyStates.IDLE:
                 // Miniboss simply paces around
@@ -133,12 +154,6 @@ public class BombMiniBossActions : BaseEnemy {
         InvokeRepeating("RandomBehavior", behaviorChangeTime, behaviorChangeTime);
 	}
 
-	// All non physics stuff occurs here (like graphic changes)
-	private void Update()
-    {
-        GraphicUpdate();
-    }
-
     // All physics stuff happens here (like moving)
 	private void FixedUpdate()
 	{
@@ -149,30 +164,10 @@ public class BombMiniBossActions : BaseEnemy {
         }
 	}
 
-	// Changes the boss's graphics depending on its state
-	private void GraphicUpdate()
-    {
-        if(bossHealth.CurrentHealth <= 0)
-        {
-            // Boss is defeated
-            bossGraphics.SwitchSprite("defeat");
-        }
-        else if(currentState == EnemyStates.ATTACK1 || currentState == EnemyStates.ATTACK2)
-        {
-            // Boss is currently attacking
-            bossGraphics.SwitchSprite("attack");
-        }
-        else
-        {
-            // Default pose
-            bossGraphics.SwitchSprite("normal");
-        }
-    }
-
     // Sets up the bahavior of the EnemyAI
     private void RandomBehavior()
     {
-        if(currentState == EnemyStates.IDLE)
+        if(CurrentState == EnemyStates.IDLE)
         {
             /*  
              * If the RANS is either a 1 or a 2, the boss will do something, IF they are in the IDLE state
@@ -182,12 +177,12 @@ public class BombMiniBossActions : BaseEnemy {
             if(rand == 1)
             {
                 // DASH ATTACK
-                currentState = EnemyStates.ATTACK1;
+                CurrentState = EnemyStates.ATTACK1;
             }
             else if(rand == 2)
             {
                 // BOMB THROW
-                currentState = EnemyStates.ATTACK2;
+                CurrentState = EnemyStates.ATTACK2;
             }
         }
     }
@@ -206,12 +201,12 @@ public class BombMiniBossActions : BaseEnemy {
         yield return new WaitForSeconds(dashTime);
 
         // We enter cooldown period
-        currentState = EnemyStates.COOLDOWN;
+        CurrentState = EnemyStates.COOLDOWN;
         yield return new WaitForSeconds(cooldownTime);
 
         // We then reset the state back
         TurnAround();
-        currentState = EnemyStates.IDLE;
+        CurrentState = EnemyStates.IDLE;
         hasActivatedCooldown = false;
         yield return null;
     }
@@ -230,11 +225,11 @@ public class BombMiniBossActions : BaseEnemy {
         yield return new WaitForFixedUpdate();
 
         // We enter cooldown
-        currentState = EnemyStates.COOLDOWN;
+        CurrentState = EnemyStates.COOLDOWN;
         yield return new WaitForSeconds(cooldownTime);
 
         // And then we reset the state
-        currentState = EnemyStates.IDLE;
+        CurrentState = EnemyStates.IDLE;
         hasActivatedCooldown = false;
         spawnedBombInstance = null;
         yield return null;

--- a/KirbyDarkDoom/Assets/Scripts/MiniBossHealth.cs
+++ b/KirbyDarkDoom/Assets/Scripts/MiniBossHealth.cs
@@ -11,7 +11,12 @@ using TMPro;
 
 public class MiniBossHealth : BaseHealth
 {
-    [Header("Sub Variables")]
+    [Header("Sub Outside References")]
+    public BombMiniBossActions enemyActions;
+    public EnemyGraphics enemyGraphics;
+    public SelfDestroy explodeComponent;
+
+    [Header("Sub UI Refs")]
     public TextMeshProUGUI bossName_UI;
     public Slider bossHealthBar_UI;
 
@@ -29,20 +34,16 @@ public class MiniBossHealth : BaseHealth
         bossHealthBar_UI.value = CurrentHealth;
 	}
 
-    // Called in an Invoke. Once this is called, the miniboss is officially defeated
-    private void Dissapear()
-    {
-        gameObject.SetActive(false);
-    }
-
-    // Once the boss is dead, it will stop moving. After X seconds it will then dissapear.
+    // Once the boss is dead, it will stop moving. After X seconds it will then explode.
 	public override void DyingAction()
     {
         if(!IsInvoking("Dissapear"))
         {
             bossName_UI.gameObject.SetActive(false);
             bossHealthBar_UI.gameObject.SetActive(false);
-            Invoke("Dissapear", 3f);
+            enemyActions.CurrentState = EnemyStates.DEFEAT;
+            canBeInhaled = true;
+            explodeComponent.enabled = true;
         }
     }
 }

--- a/KirbyDarkDoom/Assets/Scripts/PlayerController.cs
+++ b/KirbyDarkDoom/Assets/Scripts/PlayerController.cs
@@ -251,7 +251,7 @@ public class PlayerController : MonoBehaviour {
             else
             {
                 // The player takes damage accordingly
-                PlayerHurt(collision.gameObject.GetComponent<BaseEnemy>());
+                PlayerHurt(collision.gameObject.GetComponent<BaseEnemy>().attackPower);
             }
         }
 	}
@@ -309,7 +309,7 @@ public class PlayerController : MonoBehaviour {
         if(collision.gameObject.tag == "Enemy" || collision.gameObject.tag == "MiniBoss")
         {
             // The player takes damage accordingly
-            PlayerHurt(collision.gameObject.GetComponent<BaseEnemy>());
+            PlayerHurt(collision.gameObject.GetComponent<BaseEnemy>().attackPower);
         }
 	}
 
@@ -710,33 +710,6 @@ public class PlayerController : MonoBehaviour {
     }
 
     // Helper method that handles all of the necessary logic when the player gets hurt
-    private void PlayerHurt(BaseEnemy enemy)
-    {
-        if(isTakingDamage == false && playerHealth.isInvincible == false)
-        {
-            // We first stop specific states if they are valid
-            if(isDucking == true)
-            {
-                playerCollider.size = new Vector2(1,origPlayerHeight);
-                playerCollider.offset = new Vector2(0,0);
-                isDucking = false;
-            }
-            if(isInhaling == true)
-            {
-                inhaleHitboxChild.SetActive(false);
-                isInhaling = false;
-            }
-
-            // The player then takes damage and are briefly invincible
-            playerHealth.TakeDamage(enemy.attackPower);
-            playerHealth.ActivateInvincibility();
-            isTakingDamage = true;
-            playerGraphics.ChangeSprite("isDamaged");
-            Invoke("StopDamageLook", resetDamageLookTimer);
-        }
-    }
-
-    // Exactly like the helper method, only this takes a different param
     public void PlayerHurt(float attackPower)
     {
         if(isTakingDamage == false && playerHealth.isInvincible == false)

--- a/KirbyDarkDoom/Assets/Scripts/SelfDestroy.cs
+++ b/KirbyDarkDoom/Assets/Scripts/SelfDestroy.cs
@@ -21,6 +21,7 @@ public class SelfDestroy : MonoBehaviour {
     public float hitboxTimer;
 
     [Header("Outside References")]
+    public BaseHealth objectHealth;
     public BoxCollider2D hitboxRef;
     public Rigidbody2D objectRB;
     public SpriteRenderer objectSprite;
@@ -38,7 +39,13 @@ public class SelfDestroy : MonoBehaviour {
         StartCoroutine(DestroyLogic());
 	}
 
-    // Harms whatever is in the blast zone, if applicable
+    // When deactivated, we remove this object
+	private void OnDisable()
+	{
+        Destroy(gameObject);
+	}
+
+	// Harms whatever is in the blast zone, if applicable
 	private void OnTriggerStay2D(Collider2D collision)
 	{
         if(collision.gameObject.tag == "Player")
@@ -60,18 +67,12 @@ public class SelfDestroy : MonoBehaviour {
             hitboxRef.isTrigger = true;
             hitboxRef.size = new Vector2(hitboxXSize, hitboxYSize);
             objectRB.isKinematic = true;
+            objectHealth.canBeInhaled = false;
             yield return new WaitForSeconds(hitboxTimer);
         }
 
         gameObject.SetActive(false);
-        Invoke("RemoveMe", 1f);
         yield return null;
-    }
-
-    // Removes the GameObject from the scene from an Invoke call.
-    private void RemoveMe()
-    {
-        Destroy(gameObject);
     }
 
     // When selectign this object, draws out the blast zone radius


### PR DESCRIPTION
# Fixes
- Fixed the logic for inhaling an object inward
- Made `currentState` in `BombMiniBoss` private and changed the sprite changes to be delegated to a setter.
- Changed the `PlayerHurt` method to be more generic and available to be used outside the class
- Fixed the `SelfDestroy` script to properly remove itself when the player inhales this

# Additions
- Added an additional state for `EnemyStates` called `DEFEAT`
- Added a toggleable `CanBeInhaled` to `BaseHealth`
  - This now dictates whether something can be inhaled by the player
- Added miniboss exploding upon being defeated