### PR TITLE
HotFix Boss Reset and Bombs

### DIFF
--- a/KirbyDarkDoom/Assets/Scenes/TestScene.unity
+++ b/KirbyDarkDoom/Assets/Scenes/TestScene.unity
@@ -417,6 +417,10 @@ Prefab:
       propertyPath: m_Name
       value: TestBlock (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
   m_IsPrefabAsset: 0
@@ -562,7 +566,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 1929310450321584, guid: b86ace3e9e6e64acb8362b8e9f6aed09, type: 2}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114115793518424288, guid: b86ace3e9e6e64acb8362b8e9f6aed09,
         type: 2}
@@ -619,6 +623,10 @@ Prefab:
     - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
       propertyPath: m_Name
       value: TestBlock (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
@@ -850,7 +858,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4825957112730308, guid: c5972ad33a0c9410185f7b42c10de794, type: 2}
       propertyPath: m_LocalPosition.y
-      value: -2.17
+      value: 1.21
       objectReference: {fileID: 0}
     - target: {fileID: 4825957112730308, guid: c5972ad33a0c9410185f7b42c10de794, type: 2}
       propertyPath: m_LocalPosition.z
@@ -965,6 +973,10 @@ Prefab:
       propertyPath: m_Name
       value: TestBlock (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
   m_IsPrefabAsset: 0
@@ -1010,6 +1022,10 @@ Prefab:
     - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
       propertyPath: m_Name
       value: TestBlock (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
@@ -1241,6 +1257,10 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4738765917889094, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
       propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -1747,6 +1767,10 @@ Prefab:
     - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
       propertyPath: m_Name
       value: TestBlock (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1563942401213042, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd455528266094d2dbdd21cac23b3a16, type: 2}

--- a/KirbyDarkDoom/Assets/Scenes/TestScene_3.unity
+++ b/KirbyDarkDoom/Assets/Scenes/TestScene_3.unity
@@ -150,7 +150,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4279900233308310, guid: 31c868277f203414ca337849258295bb, type: 2}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4279900233308310, guid: 31c868277f203414ca337849258295bb, type: 2}
       propertyPath: m_LocalScale.x
@@ -676,11 +676,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &381940497 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1851551426365548, guid: 93cd873cd7821408f9ae6e924fa75569,
-    type: 2}
-  m_PrefabInternal: {fileID: 1374822688}
 --- !u!1 &382027189
 GameObject:
   m_ObjectHideFlags: 0
@@ -885,7 +880,7 @@ Transform:
   - {fileID: 1747746747}
   - {fileID: 1987048143}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &608511456
 Prefab:
@@ -924,7 +919,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4825957112730308, guid: c5972ad33a0c9410185f7b42c10de794, type: 2}
       propertyPath: m_RootOrder
-      value: 5
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 114708351686624562, guid: c5972ad33a0c9410185f7b42c10de794,
         type: 2}
@@ -1730,6 +1725,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114075140755556464, guid: 93cd873cd7821408f9ae6e924fa75569,
+        type: 2}
+      propertyPath: listOfRelatedObjects.Array.size
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4358065122455902, guid: 93cd873cd7821408f9ae6e924fa75569, type: 2}
       propertyPath: m_LocalPosition.x
       value: 5.79
@@ -1760,7 +1760,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4358065122455902, guid: 93cd873cd7821408f9ae6e924fa75569, type: 2}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 114389335611510454, guid: 93cd873cd7821408f9ae6e924fa75569,
         type: 2}
@@ -1781,10 +1781,10 @@ Prefab:
         type: 2}
       propertyPath: listOfRelatedObjects.Array.data[1]
       value: 
-      objectReference: {fileID: 1522685175}
+      objectReference: {fileID: 0}
     - target: {fileID: 1851551426365548, guid: 93cd873cd7821408f9ae6e924fa75569, type: 2}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 114666031931447546, guid: 93cd873cd7821408f9ae6e924fa75569,
         type: 2}
@@ -1979,73 +1979,6 @@ CanvasRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1493516927}
   m_CullTransparentMesh: 0
---- !u!1001 &1522685174
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 5.034769
-      objectReference: {fileID: 0}
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 1.497409
-      objectReference: {fileID: 0}
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4815446055628556, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 114970741703628684, guid: 41759677647284fd198c7c3626c67b82,
-        type: 2}
-      propertyPath: typeOfCollectible
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114970741703628684, guid: 41759677647284fd198c7c3626c67b82,
-        type: 2}
-      propertyPath: amount
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1457136430693118, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 212950820764786500, guid: 41759677647284fd198c7c3626c67b82,
-        type: 2}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 39c10f8aac44448648f6e3b3e5d3938d,
-        type: 3}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 41759677647284fd198c7c3626c67b82, type: 2}
-  m_IsPrefabAsset: 0
---- !u!1 &1522685175 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1457136430693118, guid: 41759677647284fd198c7c3626c67b82,
-    type: 2}
-  m_PrefabInternal: {fileID: 1522685174}
 --- !u!1 &1544106728
 GameObject:
   m_ObjectHideFlags: 0
@@ -2302,67 +2235,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 5.12, y: 2.88}
   m_EdgeRadius: 0
---- !u!1001 &1648527230
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 114224857238988532, guid: f9011da8bf837425da3c3533c3729e85,
-        type: 2}
-      propertyPath: listOfRelatedObjects.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -5.16
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -1.39
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4417167687756594, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 114224857238988532, guid: f9011da8bf837425da3c3533c3729e85,
-        type: 2}
-      propertyPath: inactiveGameObject
-      value: 
-      objectReference: {fileID: 381940497}
-    - target: {fileID: 114224857238988532, guid: f9011da8bf837425da3c3533c3729e85,
-        type: 2}
-      propertyPath: listOfRelatedObjects.Array.data[0]
-      value: 
-      objectReference: {fileID: 381940497}
-    - target: {fileID: 1705771987944446, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f9011da8bf837425da3c3533c3729e85, type: 2}
-  m_IsPrefabAsset: 0
 --- !u!1 &1693414470
 GameObject:
   m_ObjectHideFlags: 0

--- a/KirbyDarkDoom/Assets/Scripts/BombMiniBossActions.cs
+++ b/KirbyDarkDoom/Assets/Scripts/BombMiniBossActions.cs
@@ -109,6 +109,26 @@ public class BombMiniBossActions : BaseEnemy {
         }
     }
 
+    // When called, this resets all of the variables for the boss
+    public void ResetBehavior()
+    {
+        CurrentState = EnemyStates.IDLE;
+        enemyRB.velocity = Vector2.zero;
+        hasActivatedCooldown = false;
+        isMovingForward = false;
+
+        if(spawnedBombInstance != null)
+        {
+            Destroy(spawnedBombInstance);
+        }
+        spawnedBombInstance = null;
+
+        if(startFacingLeft == true && IsFacingRight == true)
+        {
+            TurnAround();
+        }
+    }
+
     // When starting up, we reset all of the enemy statuses
     private void OnEnable()
     {
@@ -215,6 +235,7 @@ public class BombMiniBossActions : BaseEnemy {
         spawnedBombInstance.GetComponent<Rigidbody2D>().isKinematic = false;
         spawnedBombInstance.GetComponent<BoxCollider2D>().isTrigger = false;
         spawnedBombInstance.GetComponent<PatrolEnemy>().moveSpeed = bombThrowSpeed;
+        spawnedBombInstance.transform.parent = null;
         yield return new WaitForFixedUpdate();
 
         // We enter cooldown

--- a/KirbyDarkDoom/Assets/Scripts/MiniBossHealth.cs
+++ b/KirbyDarkDoom/Assets/Scripts/MiniBossHealth.cs
@@ -34,7 +34,14 @@ public class MiniBossHealth : BaseHealth
         bossHealthBar_UI.value = CurrentHealth;
 	}
 
-    // Once the boss is dead, it will stop moving. After X seconds it will then explode.
+    // Does the same behavior, except it resets the boss's positioning and behavior
+	public override void Respawn()
+	{
+        base.Respawn();
+        enemyActions.ResetBehavior();
+	}
+
+	// Once the boss is dead, it will stop moving. After X seconds it will then explode.
 	public override void DyingAction()
     {
         if(!IsInvoking("Dissapear"))

--- a/KirbyDarkDoom/Assets/Scripts/SelfDestroy.cs
+++ b/KirbyDarkDoom/Assets/Scripts/SelfDestroy.cs
@@ -23,7 +23,6 @@ public class SelfDestroy : MonoBehaviour {
     [Header("Outside References")]
     public BaseHealth objectHealth;
     public BoxCollider2D hitboxRef;
-    public Rigidbody2D objectRB;
     public SpriteRenderer objectSprite;
 
     // Reconfirmes the variables being valid timers
@@ -62,15 +61,20 @@ public class SelfDestroy : MonoBehaviour {
 
         if(canExplode == true)
         {
+            if(gameObject.GetComponent<BaseEnemy>() != null)
+            {
+                gameObject.GetComponent<BaseEnemy>().StopEnemy();
+            }
+
             // If we can create a hitbox, we set it active here
             objectSprite.sprite = explosionSprite;
-            hitboxRef.isTrigger = true;
             hitboxRef.size = new Vector2(hitboxXSize, hitboxYSize);
-            objectRB.isKinematic = true;
+            hitboxRef.isTrigger = true;
             objectHealth.canBeInhaled = false;
             yield return new WaitForSeconds(hitboxTimer);
         }
 
+        // We then disable to gameobject to be destroyed
         gameObject.SetActive(false);
         yield return null;
     }


### PR DESCRIPTION
# Fixes
- Added new method that fixes issue with the boss not fully resetting when the player dies and spawns
- Fixed bomb explosion so it doesn't move after exploding